### PR TITLE
Mynewt 1.6.0

### DIFF
--- a/test/pkg.yml
+++ b/test/pkg.yml
@@ -28,3 +28,4 @@ pkg.deps:
 
 pkg.deps.SELFTEST:
     - "@apache-mynewt-core/sys/console/stub"
+    - '@apache-mynewt-core/sys/log/stub'

--- a/test/src/floatcheck_test_priv.h
+++ b/test/src/floatcheck_test_priv.h
@@ -29,7 +29,7 @@
 extern "C" {
 #endif
 
-int fc_test_suite(void);
+TEST_SUITE_DECL(fc_test_suite);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Mynewt `testutil` library is going through some changes.  I was using the unit test package in this repo to verify that the Mynewt changes are backwards incompatible.  In the process, I noticed a few other things that will break with the next release of Mynewt (1.6).